### PR TITLE
Fix TruffleHog workflow for PR scanning

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -23,11 +23,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: TruffleHog OSS
+      - name: TruffleHog OSS (Push Events)
+        if: github.event_name == 'push'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          base: ${{ github.event.before }}
+          head: ${{ github.event.after }}
+          extra_args: --debug --only-verified
+
+      - name: TruffleHog OSS (PR Events)
+        if: github.event_name == 'pull_request'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --debug --only-verified
+
+      - name: TruffleHog Full Scan (Manual Trigger)
+        if: github.event_name == 'workflow_dispatch'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ''
           head: HEAD
           extra_args: --debug --only-verified
 
@@ -35,8 +54,8 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || '' }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.event.after || 'HEAD' }}
           extra_args: |
             --debug
             --only-verified


### PR DESCRIPTION
## Summary
- Fixed the "BASE and HEAD commits are the same" error by using correct SHA references
- Added event-specific handling for push, pull request, and manual workflow triggers
- Ensured proper commit comparison for detecting secrets in PR changes

## Changes
- For push events: uses `github.event.before` and `github.event.after`
- For PR events: uses `github.event.pull_request.base.sha` and `github.event.pull_request.head.sha`
- For manual triggers: performs a full repository scan

This fix ensures TruffleHog properly scans only the changes introduced in each PR, preventing false negatives and improving performance.

🤖 Generated with [Claude Code](https://claude.ai/code)