### PR TITLE
Fix: Remove invalid TruffleHog flags

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -50,7 +50,7 @@ jobs:
           head: HEAD
           extra_args: --debug --only-verified
 
-      - name: TruffleHog Enterprise (with custom detectors for AI API keys)
+      - name: TruffleHog Detailed Scan
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
@@ -59,11 +59,6 @@ jobs:
           extra_args: |
             --debug
             --only-verified
-            --detector-keywords "openai,anthropic,claude,gpt,api_key,apikey,secret,token,bearer"
-            --exclude-paths .git
-            --exclude-paths node_modules
-            --exclude-paths .env.example
-            --exclude-paths "*.md"
             --json
         continue-on-error: true
         id: trufflehog_detailed


### PR DESCRIPTION
## Summary
- Fixed the TruffleHog workflow error by removing invalid `--detector-keywords` flag
- Removed unnecessary `--exclude-paths` options 
- Simplified the configuration while maintaining security scanning functionality

## Problem
The workflow was failing with:
```
trufflehog: error: unknown long flag '--detector-keywords', try --help
```

## Solution
Removed the unsupported flags. TruffleHog will still detect API keys from OpenAI, Anthropic, and other services using its extensive built-in detectors.

🤖 Generated with [Claude Code](https://claude.ai/code)